### PR TITLE
feat: update auth provider type validation

### DIFF
--- a/packages/taco-auth/src/providers/eip1271/eip1271.ts
+++ b/packages/taco-auth/src/providers/eip1271/eip1271.ts
@@ -1,6 +1,5 @@
 import { EIP1271_AUTH_METHOD, EIP1271AuthSignature } from './auth';
 
-export const USER_ADDRESS_PARAM_EIP1271 = ':userAddressEIP1271';
 
 export class EIP1271AuthProvider {
   constructor(

--- a/packages/taco/src/conditions/const.ts
+++ b/packages/taco/src/conditions/const.ts
@@ -1,6 +1,5 @@
 import {
   USER_ADDRESS_PARAM_DEFAULT,
-  USER_ADDRESS_PARAM_EIP1271,
   USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 } from '@nucypher/taco-auth';
 
@@ -18,7 +17,6 @@ export const CONTEXT_PARAM_PREFIX = ':';
 
 export const USER_ADDRESS_PARAMS = [
   USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
-  USER_ADDRESS_PARAM_EIP1271,
   // Ordering matters, this should always be last
   USER_ADDRESS_PARAM_DEFAULT,
 ];

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -39,13 +39,13 @@ const ERR_AUTH_PROVIDER_NOT_NEEDED_FOR_CONTEXT_PARAM = (param: string) =>
   `AuthProvider not necessary for context parameter: ${param}`;
 
 type AuthProviderType =
-  | (typeof EIP4361AuthProvider | typeof EIP1271AuthProvider)[]
+  | typeof EIP4361AuthProvider
+  | typeof EIP1271AuthProvider
   | typeof SingleSignOnEIP4361AuthProvider;
 
-
-const EXPECTED_AUTH_PROVIDER_TYPES: Record<string, AuthProviderType> = {
+const EXPECTED_AUTH_PROVIDER_TYPES: Record<string, AuthProviderType[]> = {
   [USER_ADDRESS_PARAM_DEFAULT]: [EIP4361AuthProvider, EIP1271AuthProvider],
-  [USER_ADDRESS_PARAM_EXTERNAL_EIP4361]: SingleSignOnEIP4361AuthProvider,
+  [USER_ADDRESS_PARAM_EXTERNAL_EIP4361]: [SingleSignOnEIP4361AuthProvider],
 };
 
 export const RESERVED_CONTEXT_PARAMS = [
@@ -219,18 +219,15 @@ export class ConditionContext {
         ERR_AUTH_PROVIDER_NOT_NEEDED_FOR_CONTEXT_PARAM(contextParam),
       );
     }
-    const expectedType = EXPECTED_AUTH_PROVIDER_TYPES[contextParam];
-    const isValid = Array.isArray(expectedType)
-      ? expectedType.some(type => authProvider instanceof type)
-      : authProvider instanceof expectedType;
-
-    if (!isValid) {
+    const expectedTypes = EXPECTED_AUTH_PROVIDER_TYPES[contextParam];
+    if (!expectedTypes.some((type) => authProvider instanceof type)) {
       throw new Error(
         ERR_INVALID_AUTH_PROVIDER_TYPE(contextParam, typeof authProvider),
       );
     }
 
     this.authProviders[contextParam] = authProvider;
+
   }
   public async toJson(): Promise<string> {
     const parameters = await this.toContextParameters();

--- a/packages/taco/src/conditions/context/context.ts
+++ b/packages/taco/src/conditions/context/context.ts
@@ -44,7 +44,7 @@ type AuthProviderType =
   | typeof SingleSignOnEIP4361AuthProvider;
 
 const EXPECTED_AUTH_PROVIDER_TYPES: Record<string, AuthProviderType[]> = {
-  [USER_ADDRESS_PARAM_DEFAULT]: [EIP4361AuthProvider, EIP1271AuthProvider],
+  [USER_ADDRESS_PARAM_DEFAULT]: [EIP4361AuthProvider, EIP1271AuthProvider, SingleSignOnEIP4361AuthProvider],
   [USER_ADDRESS_PARAM_EXTERNAL_EIP4361]: [SingleSignOnEIP4361AuthProvider],
 };
 

--- a/packages/taco/src/conditions/schemas/common.ts
+++ b/packages/taco/src/conditions/schemas/common.ts
@@ -1,7 +1,6 @@
 import { JSONPath } from '@astronautlabs/jsonpath';
 import {
   USER_ADDRESS_PARAM_DEFAULT,
-  USER_ADDRESS_PARAM_EIP1271,
   USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 } from '@nucypher/taco-auth';
 import { Primitive, z, ZodLiteral } from 'zod';
@@ -21,7 +20,6 @@ export const plainStringSchema = z.string().refine(
 
 export const UserAddressSchema = z.enum([
   USER_ADDRESS_PARAM_DEFAULT,
-  USER_ADDRESS_PARAM_EIP1271,
   USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 ]);
 

--- a/packages/taco/test/conditions/base/contract.test.ts
+++ b/packages/taco/test/conditions/base/contract.test.ts
@@ -201,7 +201,7 @@ describe('supports custom function abi', async () => {
 
     conditionContext.addAuthProvider(
       USER_ADDRESS_PARAM_DEFAULT,
-      authProviders[USER_ADDRESS_PARAM_DEFAULT],
+      authProviders["EIP4361"],
     );
 
     const asJson = await conditionContext.toJson();

--- a/packages/taco/test/conditions/conditions.test.ts
+++ b/packages/taco/test/conditions/conditions.test.ts
@@ -43,7 +43,7 @@ describe('conditions', () => {
     context.addCustomContextParameterValues({ ':time': 100 });
     context.addAuthProvider(
       USER_ADDRESS_PARAM_DEFAULT,
-      authProviders[USER_ADDRESS_PARAM_DEFAULT],
+      authProviders["EIP4361"],
     );
 
     expect(context).toBeDefined();

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -54,7 +54,7 @@ describe('context', () => {
     it.each([
       [USER_ADDRESS_PARAM_DEFAULT, "EIP4361"],
       [USER_ADDRESS_PARAM_EXTERNAL_EIP4361, "SSO4361"],
-    ])('serializes to json', async (userAddressParam, authProviderKey) => {
+    ])('serializes to json', async (userAddressParam, scheme) => {
       const rpcCondition = new RpcCondition({
         ...testRpcConditionObj,
         parameters: [userAddressParam],
@@ -66,7 +66,7 @@ describe('context', () => {
       const conditionContext = new ConditionContext(rpcCondition);
       conditionContext.addAuthProvider(
         userAddressParam,
-        authProviders[authProviderKey],
+        authProviders[scheme],
       );
       const asJson = await conditionContext.toJson();
 
@@ -213,8 +213,9 @@ describe('context', () => {
 
     it.each([
       [USER_ADDRESS_PARAM_DEFAULT, "EIP4361"],
+      [USER_ADDRESS_PARAM_DEFAULT, "EIP1271"],
       [USER_ADDRESS_PARAM_EXTERNAL_EIP4361, "SSO4361"],
-    ])('it supports just one provider at a time', async (userAddressParam, authProviderKey) => {
+    ])('it supports just one provider at a time', async (userAddressParam, scheme) => {
       const conditionObj = {
         ...testContractConditionObj,
         returnValueTest: {
@@ -226,7 +227,7 @@ describe('context', () => {
       const conditionContext = new ConditionContext(condition);
       conditionContext.addAuthProvider(
         userAddressParam,
-        authProviders[authProviderKey],
+        authProviders[scheme],
       );
       expect(async () => conditionContext.toContextParameters()).not.toThrow();
     });

--- a/packages/taco/test/conditions/context.test.ts
+++ b/packages/taco/test/conditions/context.test.ts
@@ -186,7 +186,7 @@ describe('context', () => {
       expect(() =>
         conditionContext.addAuthProvider(
           USER_ADDRESS_PARAM_DEFAULT,
-          authProviders["SSO4361"],
+          authProviders["Bogus"],
         ),
       ).toThrow(`Invalid AuthProvider type for ${USER_ADDRESS_PARAM_DEFAULT}`);
     });
@@ -481,7 +481,7 @@ describe('context', () => {
         const conditionContext = new ConditionContext(customContractCondition);
         conditionContext.addAuthProvider(
           USER_ADDRESS_PARAM_DEFAULT,
-          authProviders["EIP4361"],
+          authProviders["EIP1271"],
         );
 
         const asObj = await conditionContext.toContextParameters();

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -42,7 +42,6 @@ import {
   EIP4361AuthProvider,
   SingleSignOnEIP4361AuthProvider,
   USER_ADDRESS_PARAM_DEFAULT,
-  USER_ADDRESS_PARAM_EIP1271,
   USER_ADDRESS_PARAM_EXTERNAL_EIP4361,
 } from '@nucypher/taco-auth';
 import { ethers, providers, Wallet } from 'ethers';
@@ -100,14 +99,14 @@ export const fakeAuthProviders = async (
 ) => {
   const signerToUse = signer ? signer : fakeProvider().getSigner();
   return {
-    [USER_ADDRESS_PARAM_DEFAULT]: fakeEIP4351AuthProvider(signerToUse),
-    [USER_ADDRESS_PARAM_EXTERNAL_EIP4361]:
+    ["EIP4361"]: fakeEIP4361AuthProvider(signerToUse),
+    ["SSO4361"]:
       await fakeSingleSignOnEIP4361AuthProvider(signerToUse),
-    [USER_ADDRESS_PARAM_EIP1271]: await fakeEIP1271AuthProvider(signerToUse),
+    ["EIP1271"]: await fakeEIP1271AuthProvider(signerToUse)
   };
 };
 
-const fakeEIP4351AuthProvider = (signer: ethers.providers.JsonRpcSigner) => {
+const fakeEIP4361AuthProvider = (signer: ethers.providers.JsonRpcSigner) => {
   return new EIP4361AuthProvider(signer.provider, signer, TEST_SIWE_PARAMS);
 };
 

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -38,6 +38,8 @@ import {
   zip,
 } from '@nucypher/shared';
 import {
+  AuthProvider,
+  AuthSignature,
   EIP1271AuthProvider,
   EIP4361AuthProvider,
   SingleSignOnEIP4361AuthProvider,
@@ -103,19 +105,28 @@ export const fakeAuthProviders = async (
     ["SSO4361"]:
       await fakeSingleSignOnEIP4361AuthProvider(signerToUse),
     ["EIP1271"]: await fakeEIP1271AuthProvider(signerToUse),
-    ["Bogus"]: fakeBogusProvider(signerToUse),
+    ["Bogus"]: fakeBogusAuthProvider(signerToUse),
   };
 };
 
-export const fakeBogusProvider = (signer: ethers.providers.JsonRpcSigner) => {
+class BogusAuthProvider implements AuthProvider {
+  constructor(private provider: ethers.providers.Web3Provider) {}
+
+  async getOrCreateAuthSignature(): Promise<AuthSignature> {
+    throw new Error("Bogus provider");
+  }
+}
+
+export const fakeBogusAuthProvider = (signer: ethers.providers.JsonRpcSigner) => {
   const externalProvider: ethers.providers.ExternalProvider = {
     send: (request, callback) => {
       callback(new Error("Bogus provider"), null);
     },
     request: () => Promise.reject(new Error("Bogus provider"))
   };
-  return new ethers.providers.Web3Provider(externalProvider);
+  return new BogusAuthProvider(new ethers.providers.Web3Provider(externalProvider));
 };
+
 
 
 const fakeEIP4361AuthProvider = (signer: ethers.providers.JsonRpcSigner) => {

--- a/packages/test-utils/src/utils.ts
+++ b/packages/test-utils/src/utils.ts
@@ -102,9 +102,21 @@ export const fakeAuthProviders = async (
     ["EIP4361"]: fakeEIP4361AuthProvider(signerToUse),
     ["SSO4361"]:
       await fakeSingleSignOnEIP4361AuthProvider(signerToUse),
-    ["EIP1271"]: await fakeEIP1271AuthProvider(signerToUse)
+    ["EIP1271"]: await fakeEIP1271AuthProvider(signerToUse),
+    ["Bogus"]: fakeBogusProvider(signerToUse),
   };
 };
+
+export const fakeBogusProvider = (signer: ethers.providers.JsonRpcSigner) => {
+  const externalProvider: ethers.providers.ExternalProvider = {
+    send: (request, callback) => {
+      callback(new Error("Bogus provider"), null);
+    },
+    request: () => Promise.reject(new Error("Bogus provider"))
+  };
+  return new ethers.providers.Web3Provider(externalProvider);
+};
+
 
 const fakeEIP4361AuthProvider = (signer: ethers.providers.JsonRpcSigner) => {
   return new EIP4361AuthProvider(signer.provider, signer, TEST_SIWE_PARAMS);


### PR DESCRIPTION
Updates AuthProviderType to handle multiple provider types for USER_ADDRESS_PARAM_DEFAULT while maintaining single type for external EIP4361. Updates related tests to properly map auth provider keys.